### PR TITLE
Add optional ring buffer behavior

### DIFF
--- a/channelqueue.go
+++ b/channelqueue.go
@@ -32,6 +32,24 @@ func New[T any](capacity int) *ChannelQueue[T] {
 	return cq
 }
 
+// NewRing creates a new ChannelQueue with the specified buffer capacity, and
+// circular buffer behavior. When the buffer is full, writing an additional
+// item discards the oldest buffered item.
+func NewRing[T any](capacity int) *ChannelQueue[T] {
+	if capacity < 1 {
+		return New[T](capacity)
+	}
+
+	cq := &ChannelQueue[T]{
+		input:    make(chan T),
+		output:   make(chan T),
+		length:   make(chan int),
+		capacity: capacity,
+	}
+	go cq.ringBufferInput()
+	return cq
+}
+
 // In returns the write side of the channel.
 func (cq *ChannelQueue[T]) In() chan<- T {
 	return cq.input
@@ -52,8 +70,9 @@ func (cq *ChannelQueue[T]) Cap() int {
 	return cq.capacity
 }
 
-// Close closes the channel. Additional input will panic, output will continue
-// to be readable until nil.
+// Close closes the input channel. Additional input will panic, output will
+// continue to be readable until there is no more data, and then the output
+// channel is closed.
 func (cq *ChannelQueue[T]) Close() {
 	close(cq.input)
 }
@@ -61,11 +80,11 @@ func (cq *ChannelQueue[T]) Close() {
 // bufferInput is the goroutine that transfers data from the In() chan to the
 // buffer and from the buffer to the Out() chan.
 func (cq *ChannelQueue[T]) bufferInput() {
-	var input, output, inputChan chan T
+	var output chan T
 	var next T
 	var zero T
-	inputChan = cq.input
-	input = inputChan
+	inputChan := cq.input
+	input := inputChan
 
 	for input != nil || output != nil {
 		select {
@@ -92,14 +111,55 @@ func (cq *ChannelQueue[T]) bufferInput() {
 			// Try to write it to output chan.
 			output = cq.output
 			next = cq.buffer.Front()
-			if cq.capacity != -1 {
-				// If buffer at capacity, then stop accepting input.
-				if cq.buffer.Len() >= cq.capacity {
-					input = nil
-				} else {
-					input = inputChan
-				}
+		}
+
+		if cq.capacity != -1 {
+			// If buffer at capacity, then stop accepting input.
+			if cq.buffer.Len() >= cq.capacity {
+				input = nil
+			} else {
+				input = inputChan
 			}
+		}
+	}
+
+	close(cq.output)
+	close(cq.length)
+}
+
+func (cq *ChannelQueue[T]) ringBufferInput() {
+	var output chan T
+	var next T
+	var zero T
+	input := cq.input
+
+	for input != nil || output != nil {
+		select {
+		case elem, open := <-input:
+			if open {
+				// Push data from input chan to buffer.
+				cq.buffer.PushBack(elem)
+				if cq.buffer.Len() > cq.capacity {
+					cq.buffer.PopFront()
+				}
+			} else {
+				// Input chan closed; do not select input chan.
+				input = nil
+			}
+		case output <- next:
+			// Wrote buffered data to output chan. Remove item from buffer.
+			cq.buffer.PopFront()
+		case cq.length <- cq.buffer.Len():
+		}
+
+		if cq.buffer.Len() == 0 {
+			// No buffered data; do not select output chan.
+			output = nil
+			next = zero
+		} else {
+			// Try to write it to output chan.
+			output = cq.output
+			next = cq.buffer.Front()
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gammazero/channelqueue
 
 go 1.18
 
-require github.com/gammazero/deque v0.2.0
+require github.com/gammazero/deque v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gammazero/deque v0.2.0 h1:SkieyNB4bg2/uZZLxvya0Pq6diUlwx7m2TeT7GAIWaA=
-github.com/gammazero/deque v0.2.0/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
+github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
+github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=


### PR DESCRIPTION
The channelqueue has optional ring (circular buffer) behavior when created using `NewRing`.

- Fixed deadlock when using buffer of size 1.
- Update dependency