### PR TITLE
Use functional options to `New` to configure channelqueue

### DIFF
--- a/channelqueue_test.go
+++ b/channelqueue_test.go
@@ -55,6 +55,39 @@ func TestExistingInput(t *testing.T) {
 	ch.Close()
 }
 
+func TestExistingOutput(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	out := make(chan int)
+	ch := cq.New(cq.WithOutput[int](out))
+	ch.In() <- 42
+	x := <-out
+	if x != 42 {
+		t.Fatal("wrong value")
+	}
+	ch.Close()
+}
+
+func TestExistingChannels(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	in := make(chan int)
+	out := make(chan int)
+	ch := cq.New(cq.WithInput[int](in), cq.WithOutput[int](out))
+	for i := 0; i <= 100; i++ {
+		ch.In() <- i
+	}
+	ch.Close()
+
+	expect := 0
+	for x := range ch.Out() {
+		if x != expect {
+			t.Fatalf("expected %d got %d", expect, x)
+		}
+		expect++
+	}
+}
+
 func TestUnlimitedSpace(t *testing.T) {
 	defer goleak.VerifyNone(t)
 

--- a/channelqueue_test.go
+++ b/channelqueue_test.go
@@ -2,6 +2,7 @@ package channelqueue_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -176,17 +177,20 @@ func TestDouble(t *testing.T) {
 		}
 		ch.Close()
 	}()
+	var err error
 	go func() {
 		var i int
 		for val := range ch.Out() {
 			if i != val {
-				t.Fatalf("expected %d but got %d", i, val)
+				err = fmt.Errorf("expected %d but got %d", i, val)
+				return
 			}
 			recvCh.In() <- i
 			i++
 		}
 		if i != msgCount {
-			t.Fatalf("expected %d messages from ch, got %d", msgCount, i)
+			err = fmt.Errorf("expected %d messages from ch, got %d", msgCount, i)
+			return
 		}
 		recvCh.Close()
 	}()
@@ -196,6 +200,9 @@ func TestDouble(t *testing.T) {
 			t.Fatal("expected", i, "but got", val)
 		}
 		i++
+	}
+	if err != nil {
+		t.Fatal(err)
 	}
 	if i != msgCount {
 		t.Fatalf("expected %d messages from recvCh, got %d", msgCount, i)

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/gammazero/channelqueue
 go 1.22
 
 require github.com/gammazero/deque v1.0.0
+
+require go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
 github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Calling `New` without options defaults to unbounded
- Add `WithCapacity` option to specify capacity
- Add `WithInput` option to use existing channel as input channel.
- Add `WithOutput` option to use existing channel as output channel.
- Add `Shutdown` function to close and drain `ChannelQueue`
- Test for goroutine leaks after `Close` and `Shutdown`
- Allow multiple calls to `Close` and `Shutdown`
